### PR TITLE
Fix attribute parsing when attribute is of type String

### DIFF
--- a/Java/library/src/net/bankid/merchant/library/SamlResponse.java
+++ b/Java/library/src/net/bankid/merchant/library/SamlResponse.java
@@ -130,6 +130,8 @@ public class SamlResponse extends AcceptanceReportBase {
                             {
                                 if (o instanceof Element)
                                     value += ((Element) o).getTextContent();
+                                else if (o instanceof String)
+                                    value += o;
                             }
                             
                             attributes.put(key, value);


### PR DESCRIPTION
When the iDIN response contains: 
```xml
<saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">4096</saml2:AttributeValue>
```
then the parsed value is an empty String since the object is not of type Element.